### PR TITLE
Travis-CI: Work around the too old wget version  for Linux build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ cache:
 
 before_install:
   # we need a recent version of CMake
-  - sudo add-apt-repository -y ppa:andykimpe/cmake3
+  #- sudo add-apt-repository -y ppa:andykimpe/cmake3
+  #- sudo apt-get install -qq -y cmake3
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget --no-check-certificate https://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then tar -xzvf cmake-3.2.3-Linux-x86_64.tar.gz; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export PATH=$PWD/cmake-3.2.3-Linux-x86_64/bin:$PATH; fi
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y unixodbc-dev libmysqlclient-dev g++-arm-linux-gnueabi g++-arm-linux-gnueabihf clang-3.5 sloccount cppcheck 
 
@@ -49,7 +53,6 @@ matrix:
     - env:    TEST_NAME="gcc-4.8 (CMake)"
       compiler: gcc
       script:
-        - sudo apt-get install -qq -y cmake3
         - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         - sudo apt-get update -qq
         - sudo apt-get install -qq -y g++-4.8
@@ -60,19 +63,16 @@ matrix:
     - env:    TEST_NAME="clang (CMake)"
       compiler: clang
       script:
-        - sudo apt-get install -qq -y cmake3
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_TESTS=ON .. && make -j2 && cd ..
 
     - env:    TEST_NAME="arm-linux-gnueabi-g++ (CMake)"
       script:
-        - sudo apt-get install -qq -y cmake3
         - export CC="arm-linux-gnueabi-gcc"
         - export CXX="arm-linux-gnueabi-g++"
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_TESTS=ON .. && make -j2 && cd ..
 
     - env:    TEST_NAME="arm-linux-gnueabihf-g++ (CMake)"
       script:
-        - sudo apt-get install -qq -y cmake3
         - export CC="arm-linux-gnueabihf-gcc"
         - export CXX="arm-linux-gnueabihf-g++"
         - mkdir cmake-build && cd cmake-build && cmake -DENABLE_NETSSL=OFF -DENABLE_CRYPTO=OFF -DENABLE_TESTS=ON .. && make -j2 && cd ..


### PR DESCRIPTION
Hi

Below the log on CMake build error.  The workaround downloads and installs cmake 3.2 and setup the PATH accordingly.

- sudo add-apt-repository -y ppa:andykimpe/cmake3
- sudo apt-get update -qq

Setting up cmake3 (3.0.0-2) ...

--2015-11-09 11:20:00-- http://www.cmake.org/files/v3.0/cmake-3.0.0.tar.gz
Resolving www.cmake.org (www.cmake.org)... 66.194.253.19
Connecting to www.cmake.org (www.cmake.org)|66.194.253.19|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: http://cmake.org/files/v3.0/cmake-3.0.0.tar.gz [following]
--2015-11-09 11:20:01-- http://cmake.org/files/v3.0/cmake-3.0.0.tar.gz
Resolving cmake.org (cmake.org)... 66.194.253.19
Connecting to cmake.org (cmake.org)|66.194.253.19|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://cmake.org/files/v3.0/cmake-3.0.0.tar.gz [following]
--2015-11-09 11:20:01-- https://cmake.org/files/v3.0/cmake-3.0.0.tar.gz
Connecting to cmake.org (cmake.org)|66.194.253.19|:443... connected.
ERROR: no certificate subject alternative name matches
requested host name `cmake.org'.
To connect to cmake.org insecurely, use `--no-check-certificate'.
dpkg: error processing cmake3 (--configure):
subprocess installed post-installation script returned error exit status 5
Setting up libparse-debcontrol-perl (2.005-3) ...
Processing triggers for libc-bin ...
ldconfig deferred processing now taking place
Errors were encountered while processing:

cmake3

E: Sub-process /usr/bin/dpkg returned an error code (1)